### PR TITLE
fix: make python script compatible with 3.x

### DIFF
--- a/tls.py
+++ b/tls.py
@@ -1,11 +1,21 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
+from __future__ import print_function
 import json
 import os
 import ssl
 import subprocess
 import sys
-import urllib2
+try:
+  from urllib2 import urlopen
+except ImportError:
+  # For Python 3, from urllib.request import urlopen
+  print('Please make sure Python 2 is installed.')
+  if sys.platform == 'win32':
+    print('Download the latest Python 2 version from https://www.python.org/downloads/windows/')
+  elif sys.platform == 'darwin':
+    print('Run "brew install python@2" and make sure "python" points to python2')
+  sys.exit(1)
 
 ctx = ssl.create_default_context()
 ctx.check_hostname = False
@@ -23,11 +33,11 @@ def check_tls(verbose):
   port = process.stdout.readline()
   localhost_url = 'https://localhost:' + port
 
-  response = json.load(urllib2.urlopen(localhost_url, context=ctx))
+  response = json.load(urlopen(localhost_url, context=ctx))
   tls = response['protocol']
   process.wait()
 
-  if sys.platform == "linux" or sys.platform == "linux2":
+  if sys.platform in ["linux", "linux2"]:
     tutorial = "/docs/development/build-instructions-linux.md"
   elif sys.platform == "darwin":
     tutorial = "/docs/development/build-instructions-macos.md"
@@ -38,15 +48,15 @@ def check_tls(verbose):
       + "in ./docs/development/"
 
   if tls == "TLSv1" or tls == "TLSv1.1":
-    print "Your system/python combination is using an outdated security " \
-      + "protocol and will not be able to compile Electron.\n\nPlease see " \
-      + "https://github.com/electron/electron/blob/master" + tutorial + " " \
-      + "for instructions on how to update Python."
+    print("Your system/python combination is using an outdated security " +
+      "protocol and will not be able to compile Electron.\n\nPlease see " +
+      "https://github.com/electron/electron/blob/master" + tutorial + " " +
+      "for instructions on how to update Python.")
     sys.exit(1)
   else:
     if verbose:
-      print "Your Python is using " + tls + ", which is sufficient for " \
-        + "building Electron."
+      print("Your Python is using " + tls + ", which is sufficient for " +
+        "building Electron.")
 
 if __name__ == '__main__':
   check_tls(True)

--- a/tls.py
+++ b/tls.py
@@ -9,13 +9,7 @@ import sys
 try:
   from urllib2 import urlopen
 except ImportError:
-  # For Python 3, from urllib.request import urlopen
-  print('Please make sure Python 2 is installed.')
-  if sys.platform == 'win32':
-    print('Download the latest Python 2 version from https://www.python.org/downloads/windows/')
-  elif sys.platform == 'darwin':
-    print('Run "brew install python@2" and make sure "python" points to python2')
-  sys.exit(1)
+  from urllib.request import urlopen
 
 ctx = ssl.create_default_context()
 ctx.check_hostname = False
@@ -30,8 +24,8 @@ def check_tls(verbose):
     stderr=subprocess.STDOUT
   )
 
-  port = process.stdout.readline()
-  localhost_url = 'https://localhost:' + port
+  port = process.stdout.readline().strip()
+  localhost_url = u'https://localhost:{}'.format(port.decode('utf-8'))
 
   response = json.load(urlopen(localhost_url, context=ctx))
   tls = response['protocol']


### PR DESCRIPTION
See: https://github.com/electron/electron/issues/21627

* make `tls.py` parseable in both Python 2 & 3
* if the script cannot load a Python 2 import, print a human-readable error

Notes:

* this does not check to see if `python2` is available, as I didn't want to add `which` as a Node dependency - this can happen in a subsequent PR
* I added a note to determine how to make the script work for Python 3 in the event that the Electron build tooling gets migrated to Python 3